### PR TITLE
Correct book data update on params change

### DIFF
--- a/src/pages/Book/Book.jsx
+++ b/src/pages/Book/Book.jsx
@@ -28,7 +28,7 @@ function Book() {
       }
     }
     getItem();
-  }, []);
+  }, [params]);
 
   useEffect(() => {
     if (!userLoading && connectedUser && book?.title) {


### PR DESCRIPTION
Hi, 

I've fixed a bug in the useEffect hook that was preventing book data from being updated when the params changed. 
This occurred when clicking on one of the three books in the top-rated category. 

The fix involved adding the 'params' dependency to the useEffect hook, so that it correctly triggers when the parameter changes. 