### PR TITLE
Fix: Notation (excluant 0)

### DIFF
--- a/src/components/Books/BookForm/BookForm.jsx
+++ b/src/components/Books/BookForm/BookForm.jsx
@@ -49,11 +49,6 @@ function BookForm({ book, validate }) {
       if (!data.file[0]) {
         alert('Vous devez ajouter une image');
       }
-      if (!data.rating) {
-        /* eslint-disable no-param-reassign */
-        data.rating = 0;
-        /* eslint-enable no-param-reassign */
-      }
       const newBook = await addBook(data);
       if (!newBook.error) {
         validate(true);

--- a/src/components/Books/BookInfo/BookInfo.jsx
+++ b/src/components/Books/BookInfo/BookInfo.jsx
@@ -11,8 +11,8 @@ function BookInfo({ book }) {
       <p className={styles.PublishDate}>{book.year}</p>
       <p className={styles.Genre}>{book.genre}</p>
       <div className={styles.Rating}>
-        <div>{displayStars(book.averageRating)}</div>
-        <p>{`${book.averageRating}/5`}</p>
+        <div>{book.averageRating ? displayStars(book.averageRating) : 'Livre non noté'}</div>
+        <p>{!!book.averageRating && `${book.averageRating}/5`}</p>
       </div>
     </div>
   );

--- a/src/components/Books/BookRatingForm/BookRatingForm.jsx
+++ b/src/components/Books/BookRatingForm/BookRatingForm.jsx
@@ -30,7 +30,7 @@ function BookRatingForm({
     if (!connectedUser || !auth) {
       navigate(APP_ROUTES.SIGN_IN);
     }
-    const update = await rateBook(id, userId, rating);
+    const update = !!rating && await rateBook(id, userId, rating);
     console.log(update);
     if (update) {
       // eslint-disable-next-line no-underscore-dangle
@@ -42,7 +42,7 @@ function BookRatingForm({
   return (
     <div className={styles.BookRatingForm}>
       <form onSubmit={handleSubmit(onSubmit)}>
-        <p>{rating > 0 ? 'Votre Note' : 'Notez cet ouvrage'}</p>
+        <p>{userRated ? 'Votre Note' : 'Notez cet ouvrage'}</p>
         <div className={styles.Stars}>
           {!userRated ? generateStarsInputs(rating, register) : displayStars(rating)}
         </div>

--- a/src/components/Books/BookRatingForm/BookRatingForm.jsx
+++ b/src/components/Books/BookRatingForm/BookRatingForm.jsx
@@ -36,7 +36,7 @@ function BookRatingForm({
       // eslint-disable-next-line no-underscore-dangle
       setBook({ ...update, id: update._id });
     } else {
-      alert(update);
+      alert('Veuillez choisir une note entre 1 et 5.');
     }
   };
   return (

--- a/src/lib/common.js
+++ b/src/lib/common.js
@@ -121,10 +121,10 @@ export async function addBook(data) {
     author: data.author,
     year: data.year,
     genre: data.genre,
-    ratings: [{
+    ratings: data.rating ? [{
       userId,
-      grade: data.rating ? parseInt(data.rating, 10) : 0,
-    }],
+      grade: parseInt(data.rating, 10),
+    }] : [],
     averageRating: parseInt(data.rating, 10),
   };
   const bodyFormData = new FormData();


### PR DESCRIPTION
Lors de la création d'un livre, on force actuellement la note à 0 si celle-ci n'est pas renseignée.
Or, on a accès plus tard à une option pour noter un livre non noté, qui s'affiche si la note est à 0, et qu'on ne peut pas valider car il est tout de même considéré qu'une note existe.
Il serait donc pertinent de pouvoir ajouter un livre sans le noter directement afin de pouvoir ajouter une note plus tard (et ne pas accepter les notes à 0).